### PR TITLE
fix: update wrong key

### DIFF
--- a/src/components/search-bar.tsx
+++ b/src/components/search-bar.tsx
@@ -303,10 +303,7 @@ export const SearchBar = (): React.JSX.Element => {
 			return t('start', 'Start search');
 		}
 		if (inputHasFocus) {
-			return t(
-				'search.type_or_choose_suggestion',
-				'Type or choose some keywords to start a search'
-			);
+			return t('type_or_choose_suggestion', 'Type or choose some keywords to start a search');
 		}
 		// TODO: I don't know if this branch makes sense. How can it be reached?
 		//    searchInputValue is derived from query, and searchButtonsAreDisabled is true only if searchInputValue is empty,


### PR DESCRIPTION
Refs: SHELL-283

current json:
{
    "active_input_label": "Separate your keywords by a comma",
    "already_clear": "Search input is already clear",
    "app": "Search",
    "clear": "Clear search input",
    "idle_input_label": "Search in {{module}}",
    "module": "Module",
    "start": "Start search",
    "type_or_choose_suggestion": "Type or choose some keywords to start a search",
    "type_to_start_search": "Type some keywords to start a search",
    "unable_to_parse_query": "Unable to complete the search, clear it and retry",
    "label": {
        "clear_search_query": "CLEAR SEARCH"
    }
}