### PR TITLE
fix: use "t" from shell

### DIFF
--- a/src/components/results-header.test.tsx
+++ b/src/components/results-header.test.tsx
@@ -11,6 +11,10 @@ import { useSearchStore } from '../stores/search-store';
 import { SELECTORS } from '../tests/constants';
 import { screen, setup } from '../tests/utils';
 
+jest.mock('@zextras/carbonio-shell-ui', () => ({
+	t: (key: string, defaultValue: string): string => defaultValue
+}));
+
 describe('Results Header', () => {
 	it('should show the label', () => {
 		setup(<ResultsHeader label={'Test'} />);

--- a/src/components/results-header.tsx
+++ b/src/components/results-header.tsx
@@ -15,7 +15,7 @@ import {
 	Padding,
 	Text
 } from '@zextras/carbonio-design-system';
-import { useTranslation } from 'react-i18next';
+import { t } from '@zextras/carbonio-shell-ui';
 
 import { RESULT_LABEL_TYPE } from '../constants';
 import { useDisableSearch, useQuery } from '../hooks/hooks';
@@ -42,7 +42,6 @@ export const ResultsHeader = ({
 	label,
 	labelType = RESULT_LABEL_TYPE.normal
 }: ResultsHeaderProps): React.JSX.Element => {
-	const [t] = useTranslation();
 	const [query, updateQuery] = useQuery();
 	const [, setDisabled] = useDisableSearch();
 


### PR DESCRIPTION
Using "t" from shell makes translations work correctly in all modules for the component results-header.tsx.
However we noticed other components translations, such as search-bar, work using react-i18n.

This is a temporary fix until a permanent solution is properly figured out.

Refs: CO-2041