### PR TITLE
refactor: remove useless first-child selector

### DIFF
--- a/src/components/search-bar.tsx
+++ b/src/components/search-bar.tsx
@@ -34,9 +34,6 @@ const StyledChipInput = styled(ChipInput<string>)`
 const StyledContainer = styled(Container)`
 	height: 2.625rem;
 	overflow-y: hidden;
-	&:first-child {
-		transform: translateY(-0.125rem);
-	}
 `;
 
 type SearchChipInputProps<K extends keyof ChipInputProps<string>> = NonNullable<


### PR DESCRIPTION
relates to: https://github.com/zextras/carbonio-design-system/pull/531

Refs: CO-2532