### PR TITLE
fix: add sonarqube-scanner dependency to resolve CI permission issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@emotion/react": "^11.14.0",
 				"@emotion/styled": "^11.14.1",
 				"@zextras/carbonio-design-system": "11.0.2",
-				"@zextras/carbonio-shell-ui": "13.0.0",
+				"@zextras/carbonio-shell-ui": "13.0.0-devel.1766140356030",
 				"core-js": "^3.42.0",
 				"i18next": "^22.5.1",
 				"immer": "^10.1.3",
@@ -48,6 +48,7 @@
 				"jest-environment-jsdom": "^29.7.0",
 				"jest-fail-on-console": "^3.3.1",
 				"jest-junit": "^16.0.0",
+				"sonarqube-scanner": "^4.3.2",
 				"ts-node": "^10.9.2"
 			}
 		},
@@ -4225,9 +4226,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@napi-rs/canvas": {
-			"version": "0.1.84",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.84.tgz",
-			"integrity": "sha512-88FTNFs4uuiFKP0tUrPsEXhpe9dg7za9ILZJE08pGdUveMIDeana1zwfVkqRHJDPJFAmGY3dXmJ99dzsy57YnA==",
+			"version": "0.1.88",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.88.tgz",
+			"integrity": "sha512-/p08f93LEbsL5mDZFQ3DBxcPv/I4QG9EDYRRq1WNlCOXVfAHBTHMSVMwxlqG/AtnSfUr9+vgfN7MKiyDo0+Weg==",
 			"license": "MIT",
 			"optional": true,
 			"workspaces": [
@@ -4236,23 +4237,28 @@
 			"engines": {
 				"node": ">= 10"
 			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
 			"optionalDependencies": {
-				"@napi-rs/canvas-android-arm64": "0.1.84",
-				"@napi-rs/canvas-darwin-arm64": "0.1.84",
-				"@napi-rs/canvas-darwin-x64": "0.1.84",
-				"@napi-rs/canvas-linux-arm-gnueabihf": "0.1.84",
-				"@napi-rs/canvas-linux-arm64-gnu": "0.1.84",
-				"@napi-rs/canvas-linux-arm64-musl": "0.1.84",
-				"@napi-rs/canvas-linux-riscv64-gnu": "0.1.84",
-				"@napi-rs/canvas-linux-x64-gnu": "0.1.84",
-				"@napi-rs/canvas-linux-x64-musl": "0.1.84",
-				"@napi-rs/canvas-win32-x64-msvc": "0.1.84"
+				"@napi-rs/canvas-android-arm64": "0.1.88",
+				"@napi-rs/canvas-darwin-arm64": "0.1.88",
+				"@napi-rs/canvas-darwin-x64": "0.1.88",
+				"@napi-rs/canvas-linux-arm-gnueabihf": "0.1.88",
+				"@napi-rs/canvas-linux-arm64-gnu": "0.1.88",
+				"@napi-rs/canvas-linux-arm64-musl": "0.1.88",
+				"@napi-rs/canvas-linux-riscv64-gnu": "0.1.88",
+				"@napi-rs/canvas-linux-x64-gnu": "0.1.88",
+				"@napi-rs/canvas-linux-x64-musl": "0.1.88",
+				"@napi-rs/canvas-win32-arm64-msvc": "0.1.88",
+				"@napi-rs/canvas-win32-x64-msvc": "0.1.88"
 			}
 		},
 		"node_modules/@napi-rs/canvas-android-arm64": {
-			"version": "0.1.84",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.84.tgz",
-			"integrity": "sha512-pdvuqvj3qtwVryqgpAGornJLV6Ezpk39V6wT4JCnRVGy8I3Tk1au8qOalFGrx/r0Ig87hWslysPpHBxVpBMIww==",
+			"version": "0.1.88",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.88.tgz",
+			"integrity": "sha512-KEaClPnZuVxJ8smUWjV1wWFkByBO/D+vy4lN+Dm5DFH514oqwukxKGeck9xcKJhaWJGjfruGmYGiwRe//+/zQQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -4263,12 +4269,16 @@
 			],
 			"engines": {
 				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
 			}
 		},
 		"node_modules/@napi-rs/canvas-darwin-arm64": {
-			"version": "0.1.84",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.84.tgz",
-			"integrity": "sha512-A8IND3Hnv0R6abc6qCcCaOCujTLMmGxtucMTZ5vbQUrEN/scxi378MyTLtyWg+MRr6bwQJ6v/orqMS9datIcww==",
+			"version": "0.1.88",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.88.tgz",
+			"integrity": "sha512-Xgywz0dDxOKSgx3eZnK85WgGMmGrQEW7ZLA/E7raZdlEE+xXCozobgqz2ZvYigpB6DJFYkqnwHjqCOTSDGlFdg==",
 			"cpu": [
 				"arm64"
 			],
@@ -4279,12 +4289,16 @@
 			],
 			"engines": {
 				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
 			}
 		},
 		"node_modules/@napi-rs/canvas-darwin-x64": {
-			"version": "0.1.84",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.84.tgz",
-			"integrity": "sha512-AUW45lJhYWwnA74LaNeqhvqYKK/2hNnBBBl03KRdqeCD4tKneUSrxUqIv8d22CBweOvrAASyKN3W87WO2zEr/A==",
+			"version": "0.1.88",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.88.tgz",
+			"integrity": "sha512-Yz4wSCIQOUgNucgk+8NFtQxQxZV5NO8VKRl9ePKE6XoNyNVC8JDqtvhh3b3TPqKK8W5p2EQpAr1rjjm0mfBxdg==",
 			"cpu": [
 				"x64"
 			],
@@ -4295,12 +4309,16 @@
 			],
 			"engines": {
 				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
 			}
 		},
 		"node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-			"version": "0.1.84",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.84.tgz",
-			"integrity": "sha512-8zs5ZqOrdgs4FioTxSBrkl/wHZB56bJNBqaIsfPL4ZkEQCinOkrFF7xIcXiHiKp93J3wUtbIzeVrhTIaWwqk+A==",
+			"version": "0.1.88",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.88.tgz",
+			"integrity": "sha512-9gQM2SlTo76hYhxHi2XxWTAqpTOb+JtxMPEIr+H5nAhHhyEtNmTSDRtz93SP7mGd2G3Ojf2oF5tP9OdgtgXyKg==",
 			"cpu": [
 				"arm"
 			],
@@ -4311,12 +4329,16 @@
 			],
 			"engines": {
 				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
 			}
 		},
 		"node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-			"version": "0.1.84",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.84.tgz",
-			"integrity": "sha512-i204vtowOglJUpbAFWU5mqsJgH0lVpNk/Ml4mQtB4Lndd86oF+Otr6Mr5KQnZHqYGhlSIKiU2SYnUbhO28zGQA==",
+			"version": "0.1.88",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.88.tgz",
+			"integrity": "sha512-7qgaOBMXuVRk9Fzztzr3BchQKXDxGbY+nwsovD3I/Sx81e+sX0ReEDYHTItNb0Je4NHbAl7D0MKyd4SvUc04sg==",
 			"cpu": [
 				"arm64"
 			],
@@ -4327,12 +4349,16 @@
 			],
 			"engines": {
 				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
 			}
 		},
 		"node_modules/@napi-rs/canvas-linux-arm64-musl": {
-			"version": "0.1.84",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.84.tgz",
-			"integrity": "sha512-VyZq0EEw+OILnWk7G3ZgLLPaz1ERaPP++jLjeyLMbFOF+Tr4zHzWKiKDsEV/cT7btLPZbVoR3VX+T9/QubnURQ==",
+			"version": "0.1.88",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.88.tgz",
+			"integrity": "sha512-kYyNrUsHLkoGHBc77u4Unh067GrfiCUMbGHC2+OTxbeWfZkPt2o32UOQkhnSswKd9Fko/wSqqGkY956bIUzruA==",
 			"cpu": [
 				"arm64"
 			],
@@ -4343,12 +4369,16 @@
 			],
 			"engines": {
 				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
 			}
 		},
 		"node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-			"version": "0.1.84",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.84.tgz",
-			"integrity": "sha512-PSMTh8DiThvLRsbtc/a065I/ceZk17EXAATv9uNvHgkgo7wdEfTh2C3aveNkBMGByVO3tvnvD5v/YFtZL07cIg==",
+			"version": "0.1.88",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.88.tgz",
+			"integrity": "sha512-HVuH7QgzB0yavYdNZDRyAsn/ejoXB0hn8twwFnOqUbCCdkV+REna7RXjSR7+PdfW0qMQ2YYWsLvVBT5iL/mGpw==",
 			"cpu": [
 				"riscv64"
 			],
@@ -4359,12 +4389,16 @@
 			],
 			"engines": {
 				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
 			}
 		},
 		"node_modules/@napi-rs/canvas-linux-x64-gnu": {
-			"version": "0.1.84",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.84.tgz",
-			"integrity": "sha512-N1GY3noO1oqgEo3rYQIwY44kfM11vA0lDbN0orTOHfCSUZTUyiYCY0nZ197QMahZBm1aR/vYgsWpV74MMMDuNA==",
+			"version": "0.1.88",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.88.tgz",
+			"integrity": "sha512-hvcvKIcPEQrvvJtJnwD35B3qk6umFJ8dFIr8bSymfrSMem0EQsfn1ztys8ETIFndTwdNWJKWluvxztA41ivsEw==",
 			"cpu": [
 				"x64"
 			],
@@ -4375,12 +4409,16 @@
 			],
 			"engines": {
 				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
 			}
 		},
 		"node_modules/@napi-rs/canvas-linux-x64-musl": {
-			"version": "0.1.84",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.84.tgz",
-			"integrity": "sha512-vUZmua6ADqTWyHyei81aXIt9wp0yjeNwTH0KdhdeoBb6azHmFR8uKTukZMXfLCC3bnsW0t4lW7K78KNMknmtjg==",
+			"version": "0.1.88",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.88.tgz",
+			"integrity": "sha512-eSMpGYY2xnZSQ6UxYJ6plDboxq4KeJ4zT5HaVkUnbObNN6DlbJe0Mclh3wifAmquXfrlgTZt6zhHsUgz++AK6g==",
 			"cpu": [
 				"x64"
 			],
@@ -4391,12 +4429,36 @@
 			],
 			"engines": {
 				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			}
+		},
+		"node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+			"version": "0.1.88",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.88.tgz",
+			"integrity": "sha512-qcIFfEgHrchyYqRrxsCeTQgpJZ/GqHiqPcU/Fvw/ARVlQeDX1VyFH+X+0gCR2tca6UJrq96vnW+5o7buCq+erA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
 			}
 		},
 		"node_modules/@napi-rs/canvas-win32-x64-msvc": {
-			"version": "0.1.84",
-			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.84.tgz",
-			"integrity": "sha512-YSs8ncurc1xzegUMNnQUTYrdrAuaXdPMOa+iYYyAxydOtg0ppV386hyYMsy00Yip1NlTgLCseRG4sHSnjQx6og==",
+			"version": "0.1.88",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.88.tgz",
+			"integrity": "sha512-ROVqbfS4QyZxYkqmaIBBpbz/BQvAR+05FXM5PAtTYVc0uyY8Y4BHJSMdGAaMf6TdIVRsQsiq+FG/dH9XhvWCFQ==",
 			"cpu": [
 				"x64"
 			],
@@ -4407,6 +4469,10 @@
 			],
 			"engines": {
 				"node": ">= 10"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
@@ -4657,20 +4723,6 @@
 			},
 			"peerDependencies": {
 				"@testing-library/dom": ">=7.21.4"
-			}
-		},
-		"node_modules/@tinymce/tinymce-react": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@tinymce/tinymce-react/-/tinymce-react-4.3.2.tgz",
-			"integrity": "sha512-wJHZhPf2Mk3yTtdVC/uIGh+kvDgKuTw/qV13uzdChTNo68JI1l7jYMrSQOpyimDyn5LHAw0E1zFByrm1WHAVeA==",
-			"license": "MIT",
-			"dependencies": {
-				"prop-types": "^15.6.2",
-				"tinymce": "^6.0.0 || ^5.5.1"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0 || ^17.0.1 || ^16.7.0",
-				"react-dom": "^18.0.0 || ^17.0.1 || ^16.7.0"
 			}
 		},
 		"node_modules/@tootallnate/once": {
@@ -6150,18 +6202,17 @@
 			}
 		},
 		"node_modules/@zextras/carbonio-shell-ui": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/@zextras/carbonio-shell-ui/-/carbonio-shell-ui-13.0.0.tgz",
-			"integrity": "sha512-nFY6MfWgln/X/XxgAsaU6no+xA02drEEh43oRrX4HKf54oX/TcWjCe2441dFxaS9z27y6xAwbvpg5N2kVzR7Rg==",
+			"version": "13.0.0-devel.1766140356030",
+			"resolved": "https://registry.npmjs.org/@zextras/carbonio-shell-ui/-/carbonio-shell-ui-13.0.0-devel.1766140356030.tgz",
+			"integrity": "sha512-edYI+Yuj4Zkqtz5rxhHwN1xdQSPILE7HZQlOuvx0sqIZR8WvXgRAAGmLb0pU3m+wh2vWucZ05niQNvi3Ta5a3A==",
 			"license": "AGPL-3.0-only",
 			"dependencies": {
 				"@emotion/react": "^11.14.0",
 				"@emotion/styled": "^11.14.1",
 				"@fontsource/roboto": "^5.0.8",
-				"@tinymce/tinymce-react": "^4.3.2",
-				"@zextras/carbonio-design-system": "11.0.1",
-				"@zextras/carbonio-ui-preview": "4.0.0",
-				"@zextras/carbonio-ui-soap-lib": "1.0.3",
+				"@zextras/carbonio-design-system": "11.0.2",
+				"@zextras/carbonio-ui-preview": "4.0.1-devel.1",
+				"@zextras/carbonio-ui-soap-lib": "1.0.4",
 				"darkreader": "^4.9.79",
 				"date-fns": "^4.1.0",
 				"i18next": "^22.5.1",
@@ -6174,11 +6225,10 @@
 				"react-dom": "^18.3.1",
 				"react-i18next": "^12.3.1",
 				"react-router-dom": "^6.30.0",
-				"tinymce": "^6.8.4",
 				"zustand": "^5.0.3"
 			},
 			"engines": {
-				"node": "v20",
+				"node": "v22",
 				"npm": "v10"
 			},
 			"peerDependencies": {
@@ -6223,27 +6273,6 @@
 				}
 			}
 		},
-		"node_modules/@zextras/carbonio-shell-ui/node_modules/@zextras/carbonio-design-system": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/@zextras/carbonio-design-system/-/carbonio-design-system-11.0.1.tgz",
-			"integrity": "sha512-+Ka8Ut5AL8IoOQlDG097Fvi1KHSuYZVvJ/l6sB9dup6UsXxwUlP+ZONdQ7IM+h00RWpU91Uy8B0BbILSYf01lA==",
-			"license": "AGPL-3.0-only",
-			"dependencies": {
-				"@floating-ui/dom": "^1.6.11",
-				"core-js": "^3.38.1",
-				"darkreader": "^4.9.105",
-				"polished": "^4.3.1",
-				"react-datepicker": "^7.5.0"
-			},
-			"peerDependencies": {
-				"@emotion/react": "^11.14.0",
-				"@emotion/styled": "^11.14.0",
-				"date-fns": "^4.1.0",
-				"lodash": "^4.17.21",
-				"react": "^18.3.1",
-				"react-dom": "^18.3.1"
-			}
-		},
 		"node_modules/@zextras/carbonio-ui-configs": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-configs/-/carbonio-ui-configs-2.1.0.tgz",
@@ -6276,9 +6305,9 @@
 			}
 		},
 		"node_modules/@zextras/carbonio-ui-preview": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-preview/-/carbonio-ui-preview-4.0.0.tgz",
-			"integrity": "sha512-gSUHJ1iyzoWClSPfTS3JUxuhXi8qvZf70gOcvhL4Izz3Lza8sCC+2YRgM4xgBj+FhJ4a2EtKBvEMfN4tR3TG2w==",
+			"version": "4.0.1-devel.1",
+			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-preview/-/carbonio-ui-preview-4.0.1-devel.1.tgz",
+			"integrity": "sha512-YeHL7sEZe3nXeruAlYPGYuBevWsqUBda2emZFCM+CGfRp/zcri17sJraE3MfSYE/p8IOpriKoa7Q9VOU7Y3mPQ==",
 			"license": "AGPL-3.0-only",
 			"dependencies": {
 				"core-js": "^3.45.1",
@@ -6611,9 +6640,9 @@
 			}
 		},
 		"node_modules/@zextras/carbonio-ui-soap-lib": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-soap-lib/-/carbonio-ui-soap-lib-1.0.3.tgz",
-			"integrity": "sha512-is06UdbiC+ZPn+61e/1/5qpv5XsKPQwJAQzYRMftJpHMpGPR43Ll1QGdUsGFfeKr7T1jDhfuZz8Pa8L1p3HC7A==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@zextras/carbonio-ui-soap-lib/-/carbonio-ui-soap-lib-1.0.4.tgz",
+			"integrity": "sha512-vRaizwsMPC4fODiBXiNwVnKH9b9IlKWNhAu3uYzb+BvB+HMTzxb6OGLtgLqgW+PVvBb56x+ITIbdONBsVV69OQ==",
 			"license": "AGPL-3.0-only",
 			"dependencies": {
 				"@types/ua-parser-js": "^0.7.39",
@@ -6710,6 +6739,16 @@
 			},
 			"engines": {
 				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/adm-zip": {
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+			"integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0"
 			}
 		},
 		"node_modules/agent-base": {
@@ -7117,6 +7156,18 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/axios": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+			"integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"follow-redirects": "^1.15.6",
+				"form-data": "^4.0.4",
+				"proxy-from-env": "^1.1.0"
+			}
+		},
 		"node_modules/axobject-query": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -7373,6 +7424,21 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/bare-events": {
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+			"integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"bare-abort-controller": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-abort-controller": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/baseline-browser-mapping": {
 			"version": "2.9.10",
@@ -10639,6 +10705,16 @@
 				"node": ">=0.8.x"
 			}
 		},
+		"node_modules/events-universal": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+			"integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-events": "^2.7.0"
+			}
+		},
 		"node_modules/execa": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -10789,6 +10865,13 @@
 			"integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
 			"dev": true,
 			"license": "Apache-2.0"
+		},
+		"node_modules/fast-fifo": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+			"integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/fast-glob": {
 			"version": "3.3.3",
@@ -11094,6 +11177,31 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/fs-extra": {
+			"version": "11.3.2",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
+			"integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/fs-extra/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -11722,6 +11830,16 @@
 				"obuf": "^1.0.0",
 				"readable-stream": "^2.0.1",
 				"wbuf": "^1.1.0"
+			}
+		},
+		"node_modules/hpagent": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+			"integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/html-encoding-sniffer": {
@@ -16980,6 +17098,29 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/jsonfile": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/jsonfile/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
 		"node_modules/jsonparse": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -18044,6 +18185,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -18993,11 +19135,22 @@
 			"version": "15.8.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
 			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
 				"react-is": "^16.13.1"
+			}
+		},
+		"node_modules/properties-file": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/properties-file/-/properties-file-3.6.1.tgz",
+			"integrity": "sha512-9NUyJcxSqdWcJGRpPq6rT7exQbSQMPs0sK6KTvCJsLrTQRwq+hmt/wIB32ugNZmvEuSPyFO+y4nLK3vX34i5Wg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/proxy-addr": {
@@ -19023,6 +19176,13 @@
 			"engines": {
 				"node": ">= 0.10"
 			}
+		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/prr": {
 			"version": "1.0.1",
@@ -19252,9 +19412,9 @@
 			"license": "MIT"
 		},
 		"node_modules/react-pdf": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-10.2.0.tgz",
-			"integrity": "sha512-zk0DIL31oCh8cuQycM0SJKfwh4Onz0/Nwi6wTOjgtEjWGUY6eM+/vuzvOP3j70qtEULn7m1JtaeGzud1w5fY2Q==",
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-10.3.0.tgz",
+			"integrity": "sha512-2LQzC9IgNVAX8gM+6F+1t/70a9/5RWThYxc+CWAmT2LW/BRmnj+35x1os5j/nR2oldyf8L+hCAMBmVKU8wrYFA==",
 			"license": "MIT",
 			"dependencies": {
 				"clsx": "^2.0.0",
@@ -20194,6 +20354,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/slugify": {
+			"version": "1.6.6",
+			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+			"integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
 		"node_modules/sockjs": {
 			"version": "0.3.24",
 			"resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -20204,6 +20374,65 @@
 				"faye-websocket": "^0.11.3",
 				"uuid": "^8.3.2",
 				"websocket-driver": "^0.7.4"
+			}
+		},
+		"node_modules/sonarqube-scanner": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/sonarqube-scanner/-/sonarqube-scanner-4.3.2.tgz",
+			"integrity": "sha512-QI3t+yahqprjh8SWBMwQOEKLzrh35p5MQGyoIS8xm3wR2Q/CaQQeK4TEWpxGsLh2mpn1L1jNSHehSYuWdCpcvw==",
+			"dev": true,
+			"dependencies": {
+				"adm-zip": "0.5.16",
+				"axios": "1.12.2",
+				"commander": "13.1.0",
+				"fs-extra": "11.3.2",
+				"hpagent": "1.2.0",
+				"node-forge": "1.3.1",
+				"properties-file": "3.6.1",
+				"proxy-from-env": "1.1.0",
+				"semver": "7.7.2",
+				"slugify": "1.6.6",
+				"tar-stream": "3.1.7"
+			},
+			"bin": {
+				"sonar": "bin/sonar-scanner.js",
+				"sonar-scanner": "bin/sonar-scanner.js"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/sonarqube-scanner/node_modules/commander": {
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+			"integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/sonarqube-scanner/node_modules/node-forge": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+			"integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+			"dev": true,
+			"license": "(BSD-3-Clause OR GPL-2.0)",
+			"engines": {
+				"node": ">= 6.13.0"
+			}
+		},
+		"node_modules/sonarqube-scanner/node_modules/semver": {
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/source-map": {
@@ -20372,6 +20601,18 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/streamx": {
+			"version": "2.23.0",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+			"integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"events-universal": "^1.0.0",
+				"fast-fifo": "^1.3.2",
+				"text-decoder": "^1.1.0"
 			}
 		},
 		"node_modules/string_decoder": {
@@ -20666,6 +20907,33 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
+		"node_modules/tar-stream": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+			"integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"b4a": "^1.6.4",
+				"fast-fifo": "^1.2.0",
+				"streamx": "^2.15.0"
+			}
+		},
+		"node_modules/tar-stream/node_modules/b4a": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+			"integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"react-native-b4a": "*"
+			},
+			"peerDependenciesMeta": {
+				"react-native-b4a": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/terser": {
 			"version": "5.44.1",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
@@ -20818,6 +21086,31 @@
 				"node": "*"
 			}
 		},
+		"node_modules/text-decoder": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+			"integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"b4a": "^1.6.4"
+			}
+		},
+		"node_modules/text-decoder/node_modules/b4a": {
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+			"integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"react-native-b4a": "*"
+			},
+			"peerDependenciesMeta": {
+				"react-native-b4a": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/text-extensions": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.4.0.tgz",
@@ -20932,12 +21225,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
-		},
-		"node_modules/tinymce": {
-			"version": "6.8.6",
-			"resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.6.tgz",
-			"integrity": "sha512-++XYEs8lKWvZxDCjrr8Baiw7KiikraZ5JkLMg6EdnUVNKJui0IsrAADj5MsyUeFkcEryfn2jd3p09H7REvewyg==",
-			"license": "MIT"
 		},
 		"node_modules/tmpl": {
 			"version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -53,13 +53,14 @@
 		"jest-environment-jsdom": "^29.7.0",
 		"jest-fail-on-console": "^3.3.1",
 		"jest-junit": "^16.0.0",
+		"sonarqube-scanner": "^4.3.2",
 		"ts-node": "^10.9.2"
 	},
 	"dependencies": {
 		"@emotion/react": "^11.14.0",
 		"@emotion/styled": "^11.14.1",
 		"@zextras/carbonio-design-system": "11.0.2",
-		"@zextras/carbonio-shell-ui": "13.0.0",
+		"@zextras/carbonio-shell-ui": "13.0.0-devel.1766140356030",
 		"core-js": "^3.42.0",
 		"i18next": "^22.5.1",
 		"immer": "^10.1.3",


### PR DESCRIPTION
Add sonarqube-scanner as devDependency to fix 'Permission denied' error when Jenkins runs npx sonar-scanner. This ensures the scanner is installed locally with proper permissions instead of being downloaded on-the-fly by npx.# Please enter the commit message for your changes. Lines starting