### PR TITLE
fix(ci): cap vitest forks to 2 to prevent k8s CPU saturation

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
 		"type-check": "tsc --noEmit",
 		"type-check:watch": "pnpm run type-check -- --watch",
 		"lint": "eslint --ext .js,.jsx,.ts,.tsx --resolve-plugins-relative-to node_modules/@zextras/carbonio-ui-configs src",
-		"test": "vitest run"
+		"test": "vitest run",
+		"test:ci": "vitest run --maxWorkers=2"
 	},
 	"keywords": [],
 	"author": "Zextras Team <https://www.zextras.com/carbonio/>",


### PR DESCRIPTION
Fixes IN-1154: https://zextras.atlassian.net/browse/IN-1154

## Problem
vitest 4.x switched its default worker pool from `threads` to `forks`. In forks mode, `os.availableParallelism()` returns the node's physical core count, not the pod's CPU limit. One CI pod consumed 12-13 cores; three concurrent pods saturated a 15-core k8s cluster for ~1.5h and grew the Jenkins queue to 61+ items.

## Fix
This repo is a single package (no turbo/monorepo) on **vitest 4.1.9**, with no `test:ci` script previously (CI ran plain `test` via jenkins-lib-common's default fallback). Added `test:ci` with `--maxWorkers=2` (the top-level flag for vitest 4.x — `poolOptions.forks.maxForks` was removed and no longer works).

Jenkinsfile is already on `jenkins-lib-common@v4.2.0`, which auto-detects `test:ci` over `test` when present, so no Jenkinsfile change was needed.

## Verification
- `git diff` shows only the `test:ci` script addition.
- Ran `pnpm run test:ci` locally: 99 passed / 1 failed, same failure count as plain `pnpm run test` on `devel` (pre-existing, unrelated `app-view.test.tsx` i18n mock issue — not introduced by this change).

## Reference
Same pattern as carbonio-mails-ui PR #1289.